### PR TITLE
Adopt field naming

### DIFF
--- a/Reader/LineReader.cs
+++ b/Reader/LineReader.cs
@@ -41,7 +41,7 @@ internal class LineReader
             //look for the CRLF ending...
             if (curr == 13)
             {
-                //control characters are not allowed in headers, so this must be start of CRLF
+                //control characters are not allowed in fields, so this must be start of CRLF
                 curr = inputStream.ReadByte();
                 if (curr != 10)
                 {

--- a/Reader/RawRecord.cs
+++ b/Reader/RawRecord.cs
@@ -8,7 +8,7 @@ using System;
 /// - What type of record?
 /// - What's the version?
 /// - What's the content bytes and length (if any)
-/// - List of headerlines 
+/// - List of field lines
 /// </summary>
 internal class RawRecord
 {
@@ -24,7 +24,7 @@ internal class RawRecord
 
     public byte[]? ContentBytes = null;
 
-    public List<string> headers = new List<string>(16);
+    public List<string> fields = new List<string>(16);
 
     /// <summary>
     /// The byte offset of beginning of this WARC record in the file
@@ -41,9 +41,9 @@ internal class RawRecord
         Offset = offset;
     }
 
-    public void AddHeaderLine(string? headerLine)
+    public void AddFieldLine(string? fieldLine)
     {
-        if(headerLine == null)
+        if(fieldLine == null)
         {
             return;
         }
@@ -52,31 +52,31 @@ internal class RawRecord
 
         if(Version == null)
         {
-            if (string.Compare(headerLine, 0, VersionField, 0, VersionField.Length, true) == 0)
+            if (string.Compare(fieldLine, 0, VersionField, 0, VersionField.Length, true) == 0)
             {
-                Version = headerLine.Substring(VersionField.Length);
+                Version = fieldLine.Substring(VersionField.Length);
                 return;
             }
         }
 
         if (Type == null)
         {
-            if (string.Compare(headerLine, 0, TypeField, 0, TypeField.Length, true) == 0)
+            if (string.Compare(fieldLine, 0, TypeField, 0, TypeField.Length, true) == 0)
             {
-                Type = headerLine.Substring(TypeField.Length).TrimStart();
+                Type = fieldLine.Substring(TypeField.Length).TrimStart();
                 return;
             }
         }
 
         if (ContentLength == null)
         {
-            if (string.Compare(headerLine, 0, ContentLengthField, 0, ContentLengthField.Length, true) == 0)
+            if (string.Compare(fieldLine, 0, ContentLengthField, 0, ContentLengthField.Length, true) == 0)
             {
-                ContentLength = Convert.ToInt32(headerLine.Substring(ContentLengthField.Length));
+                ContentLength = Convert.ToInt32(fieldLine.Substring(ContentLengthField.Length));
                 ContentBytes = new byte[ContentLength.Value];
                 return;
             }
         }
-        headers.Add(headerLine);
+        fields.Add(fieldLine);
     }
 }

--- a/Reader/RawRecord.cs
+++ b/Reader/RawRecord.cs
@@ -12,9 +12,9 @@ using System;
 /// </summary>
 internal class RawRecord
 {
-    const string HeaderContentLength = "content-length:";
-    const string HeaderType = "warc-type:";
-    const string HeaderVersion = "warc/";
+    const string ContentLengthField = "content-length:";
+    const string TypeField = "warc-type:";
+    const string VersionField = "warc/";
 
     public string? Version { get; private set; }
 
@@ -52,27 +52,27 @@ internal class RawRecord
 
         if(Version == null)
         {
-            if (string.Compare(headerLine, 0, HeaderVersion, 0, HeaderVersion.Length, true) == 0)
+            if (string.Compare(headerLine, 0, VersionField, 0, VersionField.Length, true) == 0)
             {
-                Version = headerLine.Substring(HeaderVersion.Length);
+                Version = headerLine.Substring(VersionField.Length);
                 return;
             }
         }
 
         if (Type == null)
         {
-            if (string.Compare(headerLine, 0, HeaderType, 0, HeaderType.Length, true) == 0)
+            if (string.Compare(headerLine, 0, TypeField, 0, TypeField.Length, true) == 0)
             {
-                Type = headerLine.Substring(HeaderType.Length).TrimStart();
+                Type = headerLine.Substring(TypeField.Length).TrimStart();
                 return;
             }
         }
 
         if (ContentLength == null)
         {
-            if (string.Compare(headerLine, 0, HeaderContentLength, 0, HeaderContentLength.Length, true) == 0)
+            if (string.Compare(headerLine, 0, ContentLengthField, 0, ContentLengthField.Length, true) == 0)
             {
-                ContentLength = Convert.ToInt32(headerLine.Substring(HeaderContentLength.Length));
+                ContentLength = Convert.ToInt32(headerLine.Substring(ContentLengthField.Length));
                 ContentBytes = new byte[ContentLength.Value];
                 return;
             }

--- a/Reader/WarcFields.cs
+++ b/Reader/WarcFields.cs
@@ -24,7 +24,7 @@ public static class WarcFields
 }
 
 /// <summary>
-/// case-insentivie versions of the WARC header names
+/// case-insentivie versions of the WARC field names
 /// </summary>
 internal static class NormalizedWarcFields
 {

--- a/Reader/WarcFields.cs
+++ b/Reader/WarcFields.cs
@@ -3,9 +3,9 @@
 using System;
 
 /// <summary>
-/// Constants of properly formatted WARC header names
+/// Constants of properly formatted WARC field names
 /// </summary>
-internal static class WarcHeaders
+public static class WarcFields
 {
     public const string BlockDigest = "WARC-Block-Digest";
     public const string ConcurrentTo = "WARC-Concurrent-To";
@@ -26,7 +26,7 @@ internal static class WarcHeaders
 /// <summary>
 /// case-insentivie versions of the WARC header names
 /// </summary>
-internal static class NormalizedWarcHeaders
+internal static class NormalizedWarcFields
 {
     public const string BlockDigest = "warc-block-digest";
     public const string ConcurrentTo = "warc-concurrent-to";

--- a/Reader/WarcReader.cs
+++ b/Reader/WarcReader.cs
@@ -82,7 +82,7 @@ public class WarcReader : IEnumerable<WarcRecord>, IDisposable
     }
 
     /// <summary>
-    /// validates that a raw records contains the minimum required headers
+    /// validates that a raw records contains the minimum required fields
     /// </summary>
     /// <param name="rawRecord"></param>
     /// <exception cref="WarcFormatException"></exception>
@@ -125,7 +125,7 @@ public class WarcReader : IEnumerable<WarcRecord>, IDisposable
         do
         {
             line = lineReader.GetLine();
-            nextRecord.AddHeaderLine(line);
+            nextRecord.AddFieldLine(line);
         } while (line != null);
 
         //if the record is empty, we have hit the end of the file and have no more records

--- a/Records/MetadataRecord.cs
+++ b/Records/MetadataRecord.cs
@@ -7,7 +7,7 @@ public class MetadataRecord : WarcRecord
 {
 
     /// <summary>
-    /// Optional field. Maps to the "WARC-Concurrent-To" WARC header.
+    /// Optional field. Maps to the "WARC-Concurrent-To" WARC field.
     ///  The WARC-Record-ID of any records created as part of the same capture event as the current record. Relates this record to one or more records.
     /// </summary>
     public List<Uri> ConcurrentTo = new List<Uri>();
@@ -40,7 +40,7 @@ public class MetadataRecord : WarcRecord
 
     private string? contentType;
     /// <summary>
-    /// Optional field. Maps to the "Content-Type" WARC header.
+    /// Optional field. Maps to the "Content-Type" WARC field.
     /// Only makes sense with a non-empty Content Block
     /// </summary>
     public string? ContentType
@@ -54,7 +54,7 @@ public class MetadataRecord : WarcRecord
 
     private string? ipAddress;
     /// <summary>
-    /// Optional field. Maps to the "WARC-IP-Address" WARC header.
+    /// Optional field. Maps to the "WARC-IP-Address" WARC field.
     /// The IP address address contacted to retrieve any included content.
     /// </summary>
     public string? IpAddress
@@ -68,7 +68,7 @@ public class MetadataRecord : WarcRecord
 
     private string? identifiedPayloadType;
     /// <summary>
-    /// Optional. Maps to the "WARC-Identified-Payload-Type".
+    /// Optional. Maps to the "WARC-Identified-Payload-Type" field.
     /// The content type of the "meaningful" payload inside the content block (if any)
     /// </summary>
     public string? IdentifiedPayloadType
@@ -82,7 +82,7 @@ public class MetadataRecord : WarcRecord
 
     private string? payloadDigest;
     /// <summary>
-    /// Optional. Maps to the "WARC-Payload-Digest" header.
+    /// Optional. Maps to the "WARC-Payload-Digest" field.
     /// A digest of the "meaningful" payload inside the content block (if any)
     /// </summary>
     public string? PayloadDigest
@@ -95,13 +95,13 @@ public class MetadataRecord : WarcRecord
     }
 
     /// <summary>
-    /// Optional field. Maps to the "WARC-Target-URI" WARC header.
+    /// Optional field. Maps to the "WARC-Target-URI" WARC field.
     /// The original URI whose capture gave rise to the information content in this record
     /// </summary>
     public Uri? TargetUri { get; set; }
 
     /// <summary>
-    /// Optional field. Maps to the "WARC-Refers-To" WARC header.
+    /// Optional field. Maps to the "WARC-Refers-To" WARC field.
     /// The WARC-Record-ID of a single record for which the present record holds additional content.
     /// </summary>
     public Uri? ReferersTo { get; set; }
@@ -109,7 +109,7 @@ public class MetadataRecord : WarcRecord
     public override string Type => RecordType.Metadata;
 
     /// <summary>
-    /// Optional field. Maps to the WARC-Warcinfo-ID" WARC header.
+    /// Optional field. Maps to the WARC-Warcinfo-ID" WARC field.
     /// When present, the WARC-Warcinfo-ID indicates the WARC-Record-ID of the associated ‘warcinfo’ record for this record.
     /// </summary>
     public Uri? WarcInfoId { get; set; }
@@ -120,28 +120,28 @@ public class MetadataRecord : WarcRecord
         : base(rawRecord)
     { }
 
-    protected override void AppendRecordHeaders(StringBuilder builder)
+    protected override void AppendRecordFields(StringBuilder builder)
     {
         foreach(Uri uri in ConcurrentTo)
         {
-            builder.Append(FormatHeader(WarcFields.ConcurrentTo, FormatUrl(uri)));
+            builder.Append(FormatField(WarcFields.ConcurrentTo, FormatUrl(uri)));
         }
-        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
-        AppendHeaderIfExists(builder, WarcFields.IpAddress, IpAddress);
+        AppendFieldIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendFieldIfExists(builder, WarcFields.IpAddress, IpAddress);
 
         if(TargetUri != null)
         {
-            builder.Append(FormatHeader(WarcFields.TargetUri, TargetUri.AbsoluteUri));
+            builder.Append(FormatField(WarcFields.TargetUri, TargetUri.AbsoluteUri));
         }
 
-        AppendHeaderIfExists(builder, WarcFields.RefersTo, ReferersTo);
-        AppendHeaderIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
-        AppendHeaderIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
-        AppendHeaderIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
+        AppendFieldIfExists(builder, WarcFields.RefersTo, ReferersTo);
+        AppendFieldIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
+        AppendFieldIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
+        AppendFieldIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
 
     }
 
-    protected override bool ParseRecordHeader(string name, string value)
+    protected override bool ParseRecordField(string name, string value)
     {
         switch (name)
         {

--- a/Records/MetadataRecord.cs
+++ b/Records/MetadataRecord.cs
@@ -124,20 +124,20 @@ public class MetadataRecord : WarcRecord
     {
         foreach(Uri uri in ConcurrentTo)
         {
-            builder.Append(FormatHeader(WarcHeaders.ConcurrentTo, FormatUrl(uri)));
+            builder.Append(FormatHeader(WarcFields.ConcurrentTo, FormatUrl(uri)));
         }
-        AppendHeaderIfExists(builder, WarcHeaders.ContentType, ContentType);
-        AppendHeaderIfExists(builder, WarcHeaders.IpAddress, IpAddress);
+        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendHeaderIfExists(builder, WarcFields.IpAddress, IpAddress);
 
         if(TargetUri != null)
         {
-            builder.Append(FormatHeader(WarcHeaders.TargetUri, TargetUri.AbsoluteUri));
+            builder.Append(FormatHeader(WarcFields.TargetUri, TargetUri.AbsoluteUri));
         }
 
-        AppendHeaderIfExists(builder, WarcHeaders.RefersTo, ReferersTo);
-        AppendHeaderIfExists(builder, WarcHeaders.WarcInfoId, WarcInfoId);
-        AppendHeaderIfExists(builder, WarcHeaders.IdentifiedPayloadType, IdentifiedPayloadType);
-        AppendHeaderIfExists(builder, WarcHeaders.PayloadDigest, PayloadDigest);
+        AppendHeaderIfExists(builder, WarcFields.RefersTo, ReferersTo);
+        AppendHeaderIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
+        AppendHeaderIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
+        AppendHeaderIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
 
     }
 
@@ -145,35 +145,35 @@ public class MetadataRecord : WarcRecord
     {
         switch (name)
         {
-            case NormalizedWarcHeaders.ContentType:
+            case NormalizedWarcFields.ContentType:
                 contentType = value;
                 return true;
 
-            case NormalizedWarcHeaders.ConcurrentTo:
+            case NormalizedWarcFields.ConcurrentTo:
                 ConcurrentTo.Add(ParseUri(value));
                 return true;
 
-            case NormalizedWarcHeaders.IpAddress:
+            case NormalizedWarcFields.IpAddress:
                 ipAddress = value;
                 return true;
 
-            case NormalizedWarcHeaders.IdentifiedPayloadType:
+            case NormalizedWarcFields.IdentifiedPayloadType:
                 identifiedPayloadType = value;
                 return true;
 
-            case NormalizedWarcHeaders.PayloadDigest:
+            case NormalizedWarcFields.PayloadDigest:
                 payloadDigest = value;
                 return true;
 
-            case NormalizedWarcHeaders.RefersTo:
+            case NormalizedWarcFields.RefersTo:
                 ReferersTo = ParseUri(value);
                 return true;
 
-            case NormalizedWarcHeaders.TargetUri:
+            case NormalizedWarcFields.TargetUri:
                 TargetUri = ParseUri(value);
                 return true;
 
-            case NormalizedWarcHeaders.WarcInfoId:
+            case NormalizedWarcFields.WarcInfoId:
                 WarcInfoId = ParseUri(value);
                 return true;
         }

--- a/Records/RequestRecord.cs
+++ b/Records/RequestRecord.cs
@@ -6,14 +6,14 @@ using System.Text;
 public class RequestRecord : WarcRecord
 {
     /// <summary>
-    /// Optional field. Maps to the "WARC-Concurrent-To" WARC header.
+    /// Optional field. Maps to the "WARC-Concurrent-To" WARC field.
     ///  The WARC-Record-ID of any records created as part of the same capture event as the current record. Relates this record to one or more records.
     /// </summary>
     public List<Uri> ConcurrentTo = new List<Uri>();
 
     private string? contentType;
     /// <summary>
-    /// Optional field. Maps to the "Content-Type" WARC header.
+    /// Optional field. Maps to the "Content-Type" WARC field.
     /// Only makes sense with a non-empty Content Block
     /// </summary>
     public string? ContentType
@@ -27,7 +27,7 @@ public class RequestRecord : WarcRecord
 
     private string? ipAddress;
     /// <summary>
-    /// Optional field. Maps to the "WARC-IP-Address" WARC header.
+    /// Optional field. Maps to the "WARC-IP-Address" WARC field.
     /// The IP address address contacted to retrieve any included content.
     /// </summary>
     public string? IpAddress
@@ -41,7 +41,7 @@ public class RequestRecord : WarcRecord
 
     private string? identifiedPayloadType;
     /// <summary>
-    /// Optional. Maps to the "WARC-Identified-Payload-Type".
+    /// Optional. Maps to the "WARC-Identified-Payload-Type" field.
     /// The content type of the "meaningful" payload inside the content block (if any)
     /// </summary>
     public string? IdentifiedPayloadType
@@ -55,7 +55,7 @@ public class RequestRecord : WarcRecord
 
     private string? payloadDigest;
     /// <summary>
-    /// Optional. Maps to the "WARC-Payload-Digest" header.
+    /// Optional. Maps to the "WARC-Payload-Digest" field.
     /// A digest of the "meaningful" payload inside the content block (if any)
     /// </summary>
     public string? PayloadDigest
@@ -68,7 +68,7 @@ public class RequestRecord : WarcRecord
     }
 
     /// <summary>
-    /// Optional field. Maps to the "WARC-Target-URI" WARC header.
+    /// Optional field. Maps to the "WARC-Target-URI" WARC field.
     /// The original URI whose capture gave rise to the information content in this record
     /// </summary>
     public Uri? TargetUri { get; set; }
@@ -76,7 +76,7 @@ public class RequestRecord : WarcRecord
     public override string Type => RecordType.Request;
 
     /// <summary>
-    /// Optional field. Maps to the WARC-Warcinfo-ID" WARC header.
+    /// Optional field. Maps to the WARC-Warcinfo-ID" WARC field.
     /// When present, the WARC-Warcinfo-ID indicates the WARC-Record-ID of the associated ‘warcinfo’ record for this record.
     /// </summary>
     public Uri? WarcInfoId { get; set; }
@@ -87,27 +87,27 @@ public class RequestRecord : WarcRecord
         : base(rawRecord)
     { }
 
-    protected override void AppendRecordHeaders(StringBuilder builder)
+    protected override void AppendRecordFields(StringBuilder builder)
     {
         foreach(Uri uri in ConcurrentTo)
         {
-            builder.Append(FormatHeader(WarcFields.ConcurrentTo, FormatUrl(uri)));
+            builder.Append(FormatField(WarcFields.ConcurrentTo, FormatUrl(uri)));
         }
-        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
-        AppendHeaderIfExists(builder, WarcFields.IpAddress, IpAddress);
+        AppendFieldIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendFieldIfExists(builder, WarcFields.IpAddress, IpAddress);
 
         if(TargetUri != null)
         {
-            builder.Append(FormatHeader(WarcFields.TargetUri, TargetUri.AbsoluteUri));
+            builder.Append(FormatField(WarcFields.TargetUri, TargetUri.AbsoluteUri));
         }
 
-        AppendHeaderIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
-        AppendHeaderIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
-        AppendHeaderIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
+        AppendFieldIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
+        AppendFieldIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
+        AppendFieldIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
 
     }
 
-    protected override bool ParseRecordHeader(string name, string value)
+    protected override bool ParseRecordField(string name, string value)
     {
         switch (name)
         {

--- a/Records/RequestRecord.cs
+++ b/Records/RequestRecord.cs
@@ -91,19 +91,19 @@ public class RequestRecord : WarcRecord
     {
         foreach(Uri uri in ConcurrentTo)
         {
-            builder.Append(FormatHeader(WarcHeaders.ConcurrentTo, FormatUrl(uri)));
+            builder.Append(FormatHeader(WarcFields.ConcurrentTo, FormatUrl(uri)));
         }
-        AppendHeaderIfExists(builder, WarcHeaders.ContentType, ContentType);
-        AppendHeaderIfExists(builder, WarcHeaders.IpAddress, IpAddress);
+        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendHeaderIfExists(builder, WarcFields.IpAddress, IpAddress);
 
         if(TargetUri != null)
         {
-            builder.Append(FormatHeader(WarcHeaders.TargetUri, TargetUri.AbsoluteUri));
+            builder.Append(FormatHeader(WarcFields.TargetUri, TargetUri.AbsoluteUri));
         }
 
-        AppendHeaderIfExists(builder, WarcHeaders.WarcInfoId, WarcInfoId);
-        AppendHeaderIfExists(builder, WarcHeaders.IdentifiedPayloadType, IdentifiedPayloadType);
-        AppendHeaderIfExists(builder, WarcHeaders.PayloadDigest, PayloadDigest);
+        AppendHeaderIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
+        AppendHeaderIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
+        AppendHeaderIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
 
     }
 
@@ -111,31 +111,31 @@ public class RequestRecord : WarcRecord
     {
         switch (name)
         {
-            case NormalizedWarcHeaders.ContentType:
+            case NormalizedWarcFields.ContentType:
                 contentType = value;
                 return true;
 
-            case NormalizedWarcHeaders.ConcurrentTo:
+            case NormalizedWarcFields.ConcurrentTo:
                 ConcurrentTo.Add(ParseUri(value));
                 return true;
 
-            case NormalizedWarcHeaders.IpAddress:
+            case NormalizedWarcFields.IpAddress:
                 ipAddress = value;
                 return true;
 
-            case NormalizedWarcHeaders.IdentifiedPayloadType:
+            case NormalizedWarcFields.IdentifiedPayloadType:
                 identifiedPayloadType = value;
                 return true;
 
-            case NormalizedWarcHeaders.PayloadDigest:
+            case NormalizedWarcFields.PayloadDigest:
                 payloadDigest = value;
                 return true;
 
-            case NormalizedWarcHeaders.TargetUri:
+            case NormalizedWarcFields.TargetUri:
                 TargetUri = ParseUri(value);
                 return true;
 
-            case NormalizedWarcHeaders.WarcInfoId:
+            case NormalizedWarcFields.WarcInfoId:
                 WarcInfoId = ParseUri(value);
                 return true;
         }

--- a/Records/ResponseRecord.cs
+++ b/Records/ResponseRecord.cs
@@ -84,17 +84,17 @@ public class ResponseRecord : WarcRecord
     {
         foreach (Uri uri in ConcurrentTo)
         {
-            builder.Append(FormatHeader(WarcHeaders.ConcurrentTo, FormatUrl(uri)));
+            builder.Append(FormatHeader(WarcFields.ConcurrentTo, FormatUrl(uri)));
         }
-        AppendHeaderIfExists(builder, WarcHeaders.ContentType, ContentType);
-        AppendHeaderIfExists(builder, WarcHeaders.IpAddress, IpAddress);
+        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendHeaderIfExists(builder, WarcFields.IpAddress, IpAddress);
         if (TargetUri != null)
         {
-            builder.Append(FormatHeader(WarcHeaders.TargetUri, TargetUri.AbsoluteUri));
+            builder.Append(FormatHeader(WarcFields.TargetUri, TargetUri.AbsoluteUri));
         }
-        AppendHeaderIfExists(builder, WarcHeaders.WarcInfoId, WarcInfoId);
-        AppendHeaderIfExists(builder, WarcHeaders.IdentifiedPayloadType, IdentifiedPayloadType);
-        AppendHeaderIfExists(builder, WarcHeaders.PayloadDigest, PayloadDigest);
+        AppendHeaderIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
+        AppendHeaderIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
+        AppendHeaderIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
 
     }
 
@@ -102,31 +102,31 @@ public class ResponseRecord : WarcRecord
     {
         switch (name)
         {
-            case NormalizedWarcHeaders.ContentType:
+            case NormalizedWarcFields.ContentType:
                 ContentType = value;
                 return true;
 
-            case NormalizedWarcHeaders.ConcurrentTo:
+            case NormalizedWarcFields.ConcurrentTo:
                 ConcurrentTo.Add(ParseUri(value));
                 return true;
 
-            case NormalizedWarcHeaders.IpAddress:
+            case NormalizedWarcFields.IpAddress:
                 IpAddress = value;
                 return true;
 
-            case NormalizedWarcHeaders.IdentifiedPayloadType:
+            case NormalizedWarcFields.IdentifiedPayloadType:
                 IdentifiedPayloadType = value;
                 return true;
 
-            case NormalizedWarcHeaders.PayloadDigest:
+            case NormalizedWarcFields.PayloadDigest:
                 PayloadDigest = value;
                 return true;
 
-            case NormalizedWarcHeaders.TargetUri:
+            case NormalizedWarcFields.TargetUri:
                 TargetUri = ParseUri(value);
                 return true;
 
-            case NormalizedWarcHeaders.WarcInfoId:
+            case NormalizedWarcFields.WarcInfoId:
                 WarcInfoId = ParseUri(value);
                 return true;
         }

--- a/Records/ResponseRecord.cs
+++ b/Records/ResponseRecord.cs
@@ -7,14 +7,14 @@ public class ResponseRecord : WarcRecord
 {
 
     /// <summary>
-    /// Optional field. Maps to the "WARC-Concurrent-To" WARC header.
+    /// Optional field. Maps to the "WARC-Concurrent-To" WARC field.
     ///  The WARC-Record-ID of any records created as part of the same capture event as the current record. Relates this record to one or more records.
     /// </summary>
     public List<Uri> ConcurrentTo = new List<Uri>();
 
     private string? contentType;
     /// <summary>
-    /// Optional field. Maps to the "Content-Type" WARC header.
+    /// Optional field. Maps to the "Content-Type" WARC field.
     /// Only makes sense with a non-empty Content Block
     /// </summary>
     public string? ContentType
@@ -28,7 +28,7 @@ public class ResponseRecord : WarcRecord
 
     private string? ipAddress;
     /// <summary>
-    /// Optional field. Maps to the "WARC-IP-Address" WARC header.
+    /// Optional field. Maps to the "WARC-IP-Address" WARC field.
     /// The IP address address contacted to retrieve any included content.
     /// </summary>
     public string? IpAddress
@@ -42,7 +42,7 @@ public class ResponseRecord : WarcRecord
 
     private string? identifiedPayloadType;
     /// <summary>
-    /// Optional. Maps to the "WARC-Identified-Payload-Type".
+    /// Optional. Maps to the "WARC-Identified-Payload-Type" field.
     /// The content type of the "meaningful" payload inside the content block (if any)
     /// </summary>
     public string? IdentifiedPayloadType
@@ -55,13 +55,13 @@ public class ResponseRecord : WarcRecord
     }
 
     /// <summary>
-    /// Optional. Maps to the "WARC-Payload-Digest" header.
+    /// Optional. Maps to the "WARC-Payload-Digest" field. 
     /// A digest of the "meaningful" payload inside the content block (if any)
     /// </summary>
     public string? PayloadDigest { get; set; }
 
     /// <summary>
-    /// Optional field. Maps to the "WARC-Target-URI" WARC header.
+    /// Optional field. Maps to the "WARC-Target-URI" WARC field.
     /// The original URI whose capture gave rise to the information content in this record
     /// </summary>
     public Uri? TargetUri { get; set; }
@@ -69,7 +69,7 @@ public class ResponseRecord : WarcRecord
     public override string Type => RecordType.Response;
 
     /// <summary>
-    /// Optional field. Maps to the WARC-Warcinfo-ID" WARC header.
+    /// Optional field. Maps to the WARC-Warcinfo-ID" WARC field.
     /// When present, the WARC-Warcinfo-ID indicates the WARC-Record-ID of the associated ‘warcinfo’ record for this record.
     /// </summary>
     public Uri? WarcInfoId { get; set; }
@@ -80,25 +80,25 @@ public class ResponseRecord : WarcRecord
         : base(rawRecord)
     { }
 
-    protected override void AppendRecordHeaders(StringBuilder builder)
+    protected override void AppendRecordFields(StringBuilder builder)
     {
         foreach (Uri uri in ConcurrentTo)
         {
-            builder.Append(FormatHeader(WarcFields.ConcurrentTo, FormatUrl(uri)));
+            builder.Append(FormatField(WarcFields.ConcurrentTo, FormatUrl(uri)));
         }
-        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
-        AppendHeaderIfExists(builder, WarcFields.IpAddress, IpAddress);
+        AppendFieldIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendFieldIfExists(builder, WarcFields.IpAddress, IpAddress);
         if (TargetUri != null)
         {
-            builder.Append(FormatHeader(WarcFields.TargetUri, TargetUri.AbsoluteUri));
+            builder.Append(FormatField(WarcFields.TargetUri, TargetUri.AbsoluteUri));
         }
-        AppendHeaderIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
-        AppendHeaderIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
-        AppendHeaderIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
+        AppendFieldIfExists(builder, WarcFields.WarcInfoId, WarcInfoId);
+        AppendFieldIfExists(builder, WarcFields.IdentifiedPayloadType, IdentifiedPayloadType);
+        AppendFieldIfExists(builder, WarcFields.PayloadDigest, PayloadDigest);
 
     }
 
-    protected override bool ParseRecordHeader(string name, string value)
+    protected override bool ParseRecordField(string name, string value)
     {
         switch (name)
         {

--- a/Records/UnknownRecord.cs
+++ b/Records/UnknownRecord.cs
@@ -16,11 +16,11 @@ public class UnknownRecord : WarcRecord
         : base(rawRecord)
     { }
 
-    protected override void AppendRecordHeaders(StringBuilder builder)
+    protected override void AppendRecordFields(StringBuilder builder)
     {
     }
 
-    protected override bool ParseRecordHeader(string name, string value)
+    protected override bool ParseRecordField(string name, string value)
     {
         return false;
     }

--- a/Records/WarcInfoRecord.cs
+++ b/Records/WarcInfoRecord.cs
@@ -34,7 +34,7 @@ public class WarcInfoRecord : WarcRecord
 
     private string? contentType;
     /// <summary>
-    /// Optional field. Maps to the "Content-Type" WARC header.
+    /// Optional field. Maps to the "Content-Type" WARC field.
     /// Only makes sense with a non-empty Content Block
     /// </summary>
     public string? ContentType
@@ -48,7 +48,7 @@ public class WarcInfoRecord : WarcRecord
 
     private string? filename;
     /// <summary>
-    /// Optional field. Maps to the "WARC-Filename" WARC header.
+    /// Optional field. Maps to the "WARC-Filename" WARC field.
     /// The filename containing this warcinfo record.
     /// </summary>
     public string? Filename
@@ -68,7 +68,7 @@ public class WarcInfoRecord : WarcRecord
         : base(rawRecord)
     { }		
 
-    protected override bool ParseRecordHeader(string name, string value)
+    protected override bool ParseRecordField(string name, string value)
     {
         switch (name)
         {
@@ -83,10 +83,10 @@ public class WarcInfoRecord : WarcRecord
         return false;
     }
 
-    protected override void AppendRecordHeaders(StringBuilder builder)
+    protected override void AppendRecordFields(StringBuilder builder)
     {
-        AppendHeaderIfExists(builder, WarcFields.Filename, Filename);
-        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
+        AppendFieldIfExists(builder, WarcFields.Filename, Filename);
+        AppendFieldIfExists(builder, WarcFields.ContentType, ContentType);
     }
 }
 

--- a/Records/WarcInfoRecord.cs
+++ b/Records/WarcInfoRecord.cs
@@ -6,7 +6,6 @@ using System.Text;
 
 public class WarcInfoRecord : WarcRecord
 {
-
     /// <summary>
     /// Helper property, lets use set/get UTF-8 string for the ContentBlock for this record.
     /// If you perfer, you can just set the ContentBlock directly
@@ -73,11 +72,11 @@ public class WarcInfoRecord : WarcRecord
     {
         switch (name)
         {
-            case NormalizedWarcHeaders.ContentType:
+            case NormalizedWarcFields.ContentType:
                 contentType = value;
                 return true;
 
-            case NormalizedWarcHeaders.Filename:
+            case NormalizedWarcFields.Filename:
                 filename = value;
                 return true;
         }
@@ -86,8 +85,8 @@ public class WarcInfoRecord : WarcRecord
 
     protected override void AppendRecordHeaders(StringBuilder builder)
     {
-        AppendHeaderIfExists(builder, WarcHeaders.Filename, Filename);
-        AppendHeaderIfExists(builder, WarcHeaders.ContentType, ContentType);
+        AppendHeaderIfExists(builder, WarcFields.Filename, Filename);
+        AppendHeaderIfExists(builder, WarcFields.ContentType, ContentType);
     }
 }
 

--- a/Records/WarcRecord.cs
+++ b/Records/WarcRecord.cs
@@ -178,23 +178,23 @@ public abstract class WarcRecord
     {
         switch (name)
         {
-            case NormalizedWarcHeaders.BlockDigest:
+            case NormalizedWarcFields.BlockDigest:
                 BlockDigest = value;
                 return true;
 
-            case NormalizedWarcHeaders.Date:
+            case NormalizedWarcFields.Date:
                 Date = DateTime.Parse(value);
                 return true;
 
-            case NormalizedWarcHeaders.RecordId:
+            case NormalizedWarcFields.RecordId:
                 Id = ParseUri(value);
                 return true;
 
-            case NormalizedWarcHeaders.SegmentNumber:
+            case NormalizedWarcFields.SegmentNumber:
                 Segment = Convert.ToInt32(value);
                 return true;
 
-            case NormalizedWarcHeaders.Truncated:
+            case NormalizedWarcFields.Truncated:
                 Truncated = value;
                 return true;
         }
@@ -263,14 +263,14 @@ public abstract class WarcRecord
         // required headers first
         sb.Append($"WARC/{Version}\r\n");
         sb.Append(FormatHeader("WARC-Type", Type));
-        sb.Append(FormatHeader(WarcHeaders.Date, FormatDate(Date)));
-        sb.Append(FormatHeader(WarcHeaders.RecordId, FormatUrl(Id)));
+        sb.Append(FormatHeader(WarcFields.Date, FormatDate(Date)));
+        sb.Append(FormatHeader(WarcFields.RecordId, FormatUrl(Id)));
         sb.Append(FormatHeader("Content-Length", ContentLength.ToString()));
 
         //add common, optional headers next
-        AppendHeaderIfExists(sb, WarcHeaders.BlockDigest, BlockDigest);
-        AppendHeaderIfExists(sb, WarcHeaders.SegmentNumber, Segment);
-        AppendHeaderIfExists(sb, WarcHeaders.Truncated, Truncated);
+        AppendHeaderIfExists(sb, WarcFields.BlockDigest, BlockDigest);
+        AppendHeaderIfExists(sb, WarcFields.SegmentNumber, Segment);
+        AppendHeaderIfExists(sb, WarcFields.Truncated, Truncated);
 
         //add record-specific headers
         AppendRecordHeaders(sb);

--- a/Writer/WarcInfoFields.cs
+++ b/Writer/WarcInfoFields.cs
@@ -6,13 +6,16 @@ using System.Text;
 /// <summary>
 /// Helper class for creating WARC files for warcinfo and metadata records
 /// </summary>
-public class WarcFields : List<WarcField>
+public class WarcInfoFields : List<WarcInfoField>
 {
+	/// <summary>
+	/// The content type to use on a warcinfo record
+	/// </summary>
 	public const string ContentType = "application/warc-fields";
 
 	public void Add(string name, string value)
 	{
-		Add(new WarcField { Name = name, Value = value });
+		Add(new WarcInfoField { Name = name, Value = value });
 	}
 
 	public void Add(string name, object value)
@@ -33,7 +36,7 @@ public class WarcFields : List<WarcField>
 /// <summary>
 /// name/value pairs 
 /// </summary>
-public class WarcField
+public class WarcInfoField
 {
 	public required string Name { get; set; }
 

--- a/Writer/WarcWriter.cs
+++ b/Writer/WarcWriter.cs
@@ -136,11 +136,11 @@ public class WarcWriter : IDisposable
     /// </summary>
     /// <param name="record">A <see cref="Record"/>.</param>
     /// <param name="stream">A <see cref="Stream"/>.</param>
-    /// <remarks>Handles the headers and optional block.</remarks>
+    /// <remarks>Handles the fields and optional block.</remarks>
     private static void WriteRecordToStream(WarcRecord record, Stream stream)
     {
         // Writes the header
-        var header = record.GetHeaders();
+        var header = record.GetHeader();
         stream.Write(Encoding.UTF8.GetBytes(header));
         stream.WriteByte(CarriageReturn);
         stream.WriteByte(LineFeed);


### PR DESCRIPTION
Naming is hard.

Properly call WARC fields using the "fields" nomenclature instead of "headers". Only using the term "header" to refer to the header or a WARC record, which consists of the Version declaration, and fields